### PR TITLE
Updated for 1.12.

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9.4-R0.1-SNAPSHOT</version>
+            <version>1.12-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.inventivetalent</groupId>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>1.11.0-SNAPSHOT</version>
+            <version>1.12.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.inventivetalent</groupId>

--- a/Plugin/plugin.iml
+++ b/Plugin/plugin.iml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="api" />
+    <orderEntry type="library" name="Maven: org.spigotmc:spigot-api:1.12-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" name="Maven: com.googlecode.json-simple:json-simple:1.1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.18" level="project" />
+    <orderEntry type="library" name="Maven: net.md-5:bungeecord-chat:1.12-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent:apimanager:1.0.3-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent.packetlistener:api:3.5.0" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent:reflectionhelper:1.12.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent:mc-wrappers:1.0.3-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.6" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent:pluginannotations:1.4.7-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.projectlombok:lombok:1.16.8" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent:data-api:1.0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:findbugs:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: net.jcip:jcip-annotations:1.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:2.0.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:bcel-findbugs:6.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jFormatString:2.0.1" level="project" />
+    <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm-debug-all:5.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm-commons:5.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm-tree:5.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm:5.0.2" level="project" />
+    <orderEntry type="library" name="Maven: com.apple:AppleJavaExtensions:1.4" level="project" />
+    <orderEntry type="library" name="Maven: jaxen:jaxen:1.1.6" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
+    <orderEntry type="library" name="Maven: org.mongodb:mongodb-driver:3.0.4" level="project" />
+    <orderEntry type="library" name="Maven: org.mongodb:mongodb-driver-core:3.0.4" level="project" />
+    <orderEntry type="library" name="Maven: org.mongodb:bson:3.0.4" level="project" />
+    <orderEntry type="library" name="Maven: redis.clients:jedis:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-pool2:2.3" level="project" />
+    <orderEntry type="library" name="Maven: org.bukkit:bukkit:1.9-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.avaje:ebean:2.8.1" level="project" />
+    <orderEntry type="library" name="Maven: javax.persistence:persistence-api:1.0" level="project" />
+    <orderEntry type="library" name="Maven: mysql:mysql-connector-java:5.1.6" level="project" />
+    <orderEntry type="library" name="Maven: org.inventivetalent.spiget-update:bukkit:1.3.0" level="project" />
+  </component>
+</module>

--- a/Plugin/src/main/java/org/inventivetalent/nicknamer/NickNamerPlugin.java
+++ b/Plugin/src/main/java/org/inventivetalent/nicknamer/NickNamerPlugin.java
@@ -207,9 +207,8 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 				getLogger().info("Using temporary storage");
 				break;
 			case "local":
-				getLogger().info("Using local storage");
-				initStorageLocal();
-				break;
+				throw new RuntimeException("LOCAL STORAGE IS NO LONGER SUPPORTED! SWITCH TO SQL OR TEMP.");
+
 			case "sql":
 				getLogger().info("Using SQL storage (" + sqlUser + "@" + sqlAddress + ")");
 				initStorageSQL();
@@ -256,7 +255,7 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 				.expireAfterWrite(10, TimeUnit.MINUTES), storageExecutor);
 	}
 
-	void initStorageLocal() {
+	/*void initStorageLocal() {
 		int nickCount = -1;
 		int skinCount = -1;
 		int dataCount = -1;
@@ -296,7 +295,7 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 		if (dataCount > 0) {
 			getLogger().info("Found " + dataCount + " skin textures in database");
 			for (SkinDataEntry entry : getDatabase().find(SkinDataEntry.class).findSet()) {
-				if (System.currentTimeMillis() - entry.getLoadTime() > 3600000/*1 hour*/) {
+				if (System.currentTimeMillis() - entry.getLoadTime() > 3600000) {
 					getLogger().info("Deleting old skin for " + entry.getKey());
 					getDatabase().delete(entry);
 				}
@@ -312,7 +311,7 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 						return bean;
 					}
 				})));
-		//		SkinLoader.setSkinDataProvider(new EbeanDataProvider<Object>(Object.class/*We're using a custom parser/serializer, so this class doesn't matter*/, getDatabase(), SkinDataEntry.class) {
+		//		SkinLoader.setSkinDataProvider(new EbeanDataProvider<Object>(Object.class/*We're using a custom parser/serializer, so this class doesn't matter, getDatabase(), SkinDataEntry.class) {
 		//			@Override
 		//			public KeyValueBean newBean() {
 		//				SkinDataEntry bean = new SkinDataEntry();
@@ -320,7 +319,7 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 		//				return bean;
 		//			}
 		//		});
-	}
+	}*/
 
 	void initStorageSQL() {
 		if (sqlPass == null || sqlPass.isEmpty()) { sqlPass = null; }
@@ -389,7 +388,6 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 		});
 	}
 
-	@Override
 	public List<Class<?>> getDatabaseClasses() {
 		List<Class<?>> list = new ArrayList<>();
 		list.add(SkinDataEntry.class);


### PR DESCRIPTION
getDatabase() EBean server is no longer part of JavaPlugin, use SQL or temporary storage options instead.
Removed references to getDatabase() and throws error only when using that storage method ("local").