### PR TITLE
Fixed Java version

### DIFF
--- a/Plugin/src/main/java/org/inventivetalent/nicknamer/NickNamerPlugin.java
+++ b/Plugin/src/main/java/org/inventivetalent/nicknamer/NickNamerPlugin.java
@@ -154,7 +154,7 @@ public class NickNamerPlugin extends JavaPlugin implements Listener, PluginMessa
 	public void onLoad() {
 		String javaVersion = System.getProperty("java.version");
 		getLogger().info("Java Version: " + javaVersion);
-		int majorVersion = Integer.parseInt(javaVersion.split("\\.")[1]);
+		int majorVersion = Integer.parseInt(javaVersion.split("\\.")[0]);
 		if (majorVersion < 8) {
 			getLogger().severe("Please use Java 8 or higher (is " + majorVersion + ")");
 			throw new RuntimeException("NickNamer requires Java 8+");


### PR DESCRIPTION
It was using index 1 in the split array when it should have been using 0. This resulted in the error being incorrectly thrown.

BEFORE CHANGE:
version: 10.0.2
major version: 0

AFTER CHANGE:
version: 10.0.2
major version: 10