### PR TITLE
Fix PacketPlayOutRespawn on 1.16.2

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>1.14.5-SNAPSHOT</version>
+            <version>1.15.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.inventivetalent</groupId>


### PR DESCRIPTION
This pull request fixes a `NoSuchMethodException` when attempting to create a `PacketPlayOutRespawn` packet on 1.16.2.

In 1.16.2 the constructor for that packet now takes a direct `DimensionManager` instead of a `ResourceKey<DimensionManager>`.

I have also updated ReflectionHelper to the current latest version (1.15.1-SNAPSHOT) in order to check if the server version is 1.16.2 or above.